### PR TITLE
feat: allow endpoint configuration in Caddyfile

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,5 +1,32 @@
 :8082
 
+handle /__ready {
+    respond OK 200
+}
+
 route {
-    lura *
+    lura {
+        timeout 10s
+        cache_ttl 3600s
+
+        endpoint /users/{user} {
+            method GET
+            concurrent_calls 2
+            timeout 1000s
+            cache_ttl 3600s
+
+            backend {$BACKEND_HOST} {
+                url_pattern /registered/{user}
+                allow id name email
+                mapping {
+                    email>personal_email
+                }
+            }
+
+            backend {$BACKEND_HOST} {
+                url_pattern /users/{user}/permissions
+                group permissions
+            }
+        }
+    }
 }

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -1,0 +1,221 @@
+package caddylura
+
+import (
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	"strconv"
+	"strings"
+)
+
+func init() {
+	httpcaddyfile.RegisterHandlerDirective("lura", parseCaddyfile)
+}
+
+func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error) {
+	l := new(Lura)
+
+	err := l.UnmarshalCaddyfile(h.Dispenser)
+
+	return l, err
+}
+
+func (l *Lura) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	// consume directive name
+	d.Next()
+
+	var err error
+	endpoints := make([]Endpoint, 0)
+
+	for d.NextBlock(0) {
+		switch d.Val() {
+		case "timeout":
+			l.Timeout, err = unmarshalDuration(d)
+			if err != nil {
+				return err
+			}
+
+			break
+		case "cache_ttl":
+			l.CacheTTL, err = unmarshalDuration(d)
+			if err != nil {
+				return err
+			}
+
+			break
+		case "endpoint":
+			e, err := unmarshalEndpoint(d)
+			if err != nil {
+				return err
+			}
+			endpoints = append(endpoints, e)
+
+		default:
+			return d.Errf("unrecognized subdirective %s", d.Val())
+		}
+	}
+
+	l.Endpoints = endpoints
+
+	return nil
+}
+
+func unmarshalDuration(d *caddyfile.Dispenser) (caddy.Duration, error) {
+	durArg, err := unmarshalSingleArg(d)
+	if err != nil {
+		return 0, err
+	}
+	dur, err := caddy.ParseDuration(durArg)
+	if err != nil {
+		return 0, d.Errf("bad duration value %s: %v", d.Val(), err)
+	}
+	return caddy.Duration(dur), nil
+}
+
+func unmarshalEndpoint(d *caddyfile.Dispenser) (e Endpoint, err error) {
+
+	args := d.RemainingArgs()
+	if len(args) > 0 {
+		e.URLPattern = args[0]
+	}
+
+	backends := make([]Backend, 0)
+
+	curNesting := d.Nesting()
+	for d.NextBlock(curNesting) {
+		switch d.Val() {
+		case "url_pattern":
+			e.URLPattern, err = unmarshalSingleArg(d)
+			if err != nil {
+				return
+			}
+			break
+
+		case "method":
+			e.Method, err = unmarshalSingleArg(d)
+			if err != nil {
+				return
+			}
+			break
+
+		case "backend":
+			var b Backend
+			b, err = unmarshalBackend(d)
+			if err != nil {
+				return
+			}
+			backends = append(backends, b)
+
+		case "concurrent_calls":
+			var arg string
+			arg, err = unmarshalSingleArg(d)
+			if err != nil {
+				return
+			}
+			e.ConcurrentCalls, err = strconv.Atoi(arg)
+			if err != nil {
+				err = d.Errf("failed to parse concurrent call: %w", err)
+				return
+			}
+			break
+
+		case "timeout":
+			e.Timeout, err = unmarshalDuration(d)
+			if err != nil {
+				return
+			}
+			break
+
+		case "cache_ttl":
+			e.CacheTTL, err = unmarshalDuration(d)
+			if err != nil {
+				return
+			}
+			break
+
+		default:
+			err = d.Errf("unrecognized subdirective '%s' while parsing endpoint ", d.Val())
+			return
+		}
+	}
+
+	e.Backends = backends
+
+	return
+}
+
+func unmarshalBackend(d *caddyfile.Dispenser) (b Backend, err error) {
+	upstreams := make([]string, 0)
+	for _, u := range d.RemainingArgs() {
+		upstreams = append(upstreams, u)
+	}
+
+	curNesting := d.Nesting()
+	for d.NextBlock(curNesting) {
+		switch d.Val() {
+		case "to":
+			for _, u := range d.RemainingArgs() {
+				upstreams = append(upstreams, u)
+			}
+			break
+
+		case "url_pattern":
+			b.URLPattern, err = unmarshalSingleArg(d)
+			if err != nil {
+				return
+			}
+			break
+
+		case "allow":
+			b.AllowList = d.RemainingArgs()
+			break
+
+		case "group":
+			b.Group, err = unmarshalSingleArg(d)
+			if err != nil {
+				return
+			}
+			break
+
+		case "method":
+			b.Method, err = unmarshalSingleArg(d)
+			if err != nil {
+				return
+			}
+			break
+
+		case "mapping":
+			mapping := make(map[string]string)
+			nesting := d.Nesting()
+			for d.NextBlock(nesting) {
+				m := d.Val()
+				if strings.Contains(m, ">") {
+					parts := strings.Split(m, ">")
+					mapping[parts[0]] = parts[1]
+				} else {
+					err = d.Errf("mapping should be in the format source_field>target_field, but got: '%s'", m)
+					return
+				}
+			}
+			b.Mapping = mapping
+			break
+		default:
+			err = d.Errf("unrecognized subdirective '%s' while parsing backend ", d.Val())
+			return
+		}
+	}
+
+	b.Host = upstreams
+
+	return
+}
+
+func unmarshalSingleArg(d *caddyfile.Dispenser) (string, error) {
+	args := d.RemainingArgs()
+	if len(args) != 1 {
+		return "", d.ArgErr()
+	}
+
+	return args[0], nil
+}

--- a/caddyfile_test.go
+++ b/caddyfile_test.go
@@ -1,0 +1,102 @@
+package caddylura
+
+import (
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestParseCaddyFile(t *testing.T) {
+	input := `
+lura {
+	timeout 10s
+	cache_ttl 360s
+
+    endpoint /users/{user} {
+        method GET
+
+        backend {
+            to http://mock:8081
+			url_pattern /registered/{user}
+            allow id name email
+            mapping {
+                email>personal_email
+            }
+        }
+
+		backend {
+			to http://mock:8081
+			url_pattern /users/{user}/permissions
+			group permissions
+		}
+		
+		concurrent_calls 2
+		timeout 1000s
+		cache_ttl 3600s
+    }
+
+	endpoint {
+		url_pattern /foo/bar
+		method POST
+		backend http://mock:8082 http://mock:8083 {
+			url_pattern /baz
+			method PUT
+		}
+	}
+}
+`
+	d := caddyfile.NewTestDispenser(input)
+
+	l := new(Lura)
+	err := l.UnmarshalCaddyfile(d)
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	expected := &Lura{
+		Timeout:  caddy.Duration(10 * time.Second),
+		CacheTTL: caddy.Duration(360 * time.Second),
+		Endpoints: []Endpoint{
+			{
+				Method:     "GET",
+				URLPattern: "/users/{user}",
+				Backends: []Backend{
+					{
+						Host:       []string{"http://mock:8081"},
+						URLPattern: "/registered/{user}",
+						AllowList:  []string{"id", "name", "email"},
+						Mapping: map[string]string{
+							"email": "personal_email",
+						},
+					},
+					{
+						Host:       []string{"http://mock:8081"},
+						URLPattern: "/users/{user}/permissions",
+						Group:      "permissions",
+					},
+				},
+				ConcurrentCalls: 2,
+				Timeout:         caddy.Duration(1000 * time.Second),
+				CacheTTL:        caddy.Duration(3600 * time.Second),
+			},
+			{
+				Method:     "POST",
+				URLPattern: "/foo/bar",
+				Backends: []Backend{
+					{
+						Host: []string{
+							"http://mock:8082",
+							"http://mock:8083",
+						},
+						URLPattern: "/baz",
+						Method:     "PUT",
+					},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, expected, l)
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,32 +11,28 @@ services:
     ports:
       - 8081:8081
 
-  lura:
-    image: golang:1.22
-    working_dir: /media
-    ports:
-      - 8080:8080
-    command:
-      - go
-      - run
-      - /media/cmd/lura/
-    volumes:
-      - ./:/media
-
   hurl:
     image: ghcr.io/orange-opensource/hurl:latest
     volumes:
       - ./acceptance-tests/test-cases:/tests:ro
     depends_on:
-      - lura
+      caddylura:
+        condition: service_healthy
     entrypoint:
       - tail
       - -f
       - /dev/null
 
   caddylura:
+    environment:
+      BACKEND_HOST: http://mock:8081
     image: golang:1.22
     working_dir: /media
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8082/__ready"]
+      start_period: "10s"
+    depends_on:
+      - mock
     ports:
       - 8082:8082
     command:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.22.1
 
 require (
 	github.com/caddyserver/caddy/v2 v2.8.0
+	github.com/gin-gonic/gin v1.9.1
 	github.com/luraproject/lura/v2 v2.6.3
+	github.com/stretchr/testify v1.9.0
 )
 
 require (
@@ -28,6 +30,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
 	github.com/chzyer/readline v1.5.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.3 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgraph-io/badger v1.6.2 // indirect
 	github.com/dgraph-io/badger/v2 v2.2007.4 // indirect
 	github.com/dgraph-io/ristretto v0.1.0 // indirect
@@ -38,7 +41,6 @@ require (
 	github.com/fxamacker/cbor/v2 v2.6.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
-	github.com/gin-gonic/gin v1.9.1 // indirect
 	github.com/go-chi/chi/v5 v5.0.12 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.3 // indirect
 	github.com/go-kit/kit v0.13.0 // indirect
@@ -94,6 +96,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/pires/go-proxyproto v0.7.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect


### PR DESCRIPTION
The lura api gateway configuration was statically defined in source code, which is not ideal for any environments other than testing.

Implement Caddyfile unmarshalling so that basic configuration of lura might be customizable.

At this point not all lura configurations was made available, but only the bare minimum for simple endpoint definitions.