### PR TITLE
chore: wrap lura logger with caddy logger

### DIFF
--- a/app.go
+++ b/app.go
@@ -88,7 +88,7 @@ func (l *Lura) Provision(ctx caddy.Context) error {
 		}
 	}
 
-	luraHandler, err := lura.NewHandler(cfg)
+	luraHandler, err := lura.NewHandler(cfg, ctx.Logger())
 	if err != nil {
 		return err
 	}

--- a/internal/lura/logger.go
+++ b/internal/lura/logger.go
@@ -1,0 +1,38 @@
+package lura
+
+import (
+	"github.com/luraproject/lura/v2/logging"
+	"go.uber.org/zap"
+)
+
+type caddyLogger struct {
+	logger *zap.SugaredLogger
+}
+
+func newLogger(l *zap.Logger) logging.Logger {
+	return &caddyLogger{logger: l.Sugar()}
+}
+
+func (c *caddyLogger) Debug(v ...interface{}) {
+	c.logger.Debug(v...)
+}
+
+func (c *caddyLogger) Info(v ...interface{}) {
+	c.logger.Info(v...)
+}
+
+func (c *caddyLogger) Warning(v ...interface{}) {
+	c.logger.Warn(v...)
+}
+
+func (c *caddyLogger) Error(v ...interface{}) {
+	c.logger.Error(v...)
+}
+
+func (c *caddyLogger) Critical(v ...interface{}) {
+	c.logger.Panic(v...)
+}
+
+func (c *caddyLogger) Fatal(v ...interface{}) {
+	c.logger.Fatal(v...)
+}

--- a/internal/lura/lura.go
+++ b/internal/lura/lura.go
@@ -9,16 +9,16 @@ import (
 	"github.com/luraproject/lura/v2/proxy"
 	"github.com/luraproject/lura/v2/router/mux"
 	"github.com/luraproject/lura/v2/transport/http/client"
+	"go.uber.org/zap"
 	"net/http"
-	"os"
 )
 
 var (
 	backendHttpProxy = proxy.CustomHTTPProxyFactory(client.NewHTTPClient)
 )
 
-func NewHandler(cfg config.ServiceConfig) (http.Handler, error) {
-	logger, _ := logging.NewLogger("DEBUG", os.Stdout, "[LURA]")
+func NewHandler(cfg config.ServiceConfig, zl *zap.Logger) (http.Handler, error) {
+	logger := newLogger(zl)
 
 	var luraHandler http.Handler
 


### PR DESCRIPTION
The logging implementation of lura was not the same, causing some divergences in logging style.

Create an adapter to allow using caddy logger (zap) as a lura logger.