### PR TITLE
feat: add config for helper endpoints

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,3 +1,9 @@
+{
+    log {
+        level DEBUG
+    }
+}
+
 :{$LISTEN_PORT}
 
 handle /__ready {
@@ -7,6 +13,9 @@ handle /__ready {
 lura {
     timeout 10s
     cache_ttl 3600s
+
+    debug_endpoint
+    echo_endpoint /__custom/echo
 
     endpoint /users/{user} {
         method GET

--- a/acceptance-tests/test-cases/debug-endpoint.hurl
+++ b/acceptance-tests/test-cases/debug-endpoint.hurl
@@ -1,0 +1,6 @@
+GET http://caddylura:8082/__debug/any/
+
+HTTP 200
+
+[Asserts]
+jsonpath "$.message" == "pong"

--- a/acceptance-tests/test-cases/echo-endpoint.hurl
+++ b/acceptance-tests/test-cases/echo-endpoint.hurl
@@ -1,0 +1,11 @@
+GET http://caddylura:8082/__custom/echo/baz/
+
+{
+    "foo": "bar"
+}
+
+HTTP 200
+
+[Asserts]
+jsonpath "$.req_uri" == "/__custom/echo/baz/"
+jsonpath "$.req_body" contains "bar"

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -46,11 +46,27 @@ func (l *Lura) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 
 			break
 		case "endpoint":
-			e, err := unmarshalEndpoint(d)
+			var e Endpoint
+			e, err = unmarshalEndpoint(d)
 			if err != nil {
 				return err
 			}
 			endpoints = append(endpoints, e)
+			break
+
+		case "debug_endpoint":
+			l.DebugEndpoint, err = unmarshalHelperEndpoint(d)
+			if err != nil {
+				return err
+			}
+			break
+
+		case "echo_endpoint":
+			l.EchoEndpoint, err = unmarshalHelperEndpoint(d)
+			if err != nil {
+				return err
+			}
+			break
 
 		default:
 			return d.Errf("unrecognized subdirective %s", d.Val())
@@ -219,4 +235,22 @@ func unmarshalSingleArg(d *caddyfile.Dispenser) (string, error) {
 	}
 
 	return args[0], nil
+}
+
+func unmarshalHelperEndpoint(d *caddyfile.Dispenser) (HelperEndpoint, error) {
+	args := d.RemainingArgs()
+	if len(args) > 1 {
+		return HelperEndpoint{}, d.ArgErr()
+	}
+
+	if len(args) == 1 {
+		return HelperEndpoint{
+			URLPattern: args[0],
+			Enabled:    true,
+		}, nil
+	}
+
+	return HelperEndpoint{
+		Enabled: true,
+	}, nil
 }

--- a/caddyfile_test.go
+++ b/caddyfile_test.go
@@ -13,6 +13,9 @@ func TestParseCaddyFile(t *testing.T) {
 lura {
 	timeout 10s
 	cache_ttl 360s
+	
+	debug_endpoint /api/__debug
+	echo_endpoint
 
     endpoint /users/{user} {
         method GET
@@ -58,6 +61,14 @@ lura {
 	expected := &Lura{
 		Timeout:  caddy.Duration(10 * time.Second),
 		CacheTTL: caddy.Duration(360 * time.Second),
+		DebugEndpoint: HelperEndpoint{
+			URLPattern: "/api/__debug",
+			Enabled:    true,
+		},
+		EchoEndpoint: HelperEndpoint{
+			URLPattern: "",
+			Enabled:    true,
+		},
 		Endpoints: []Endpoint{
 			{
 				Method:     "GET",


### PR DESCRIPTION
Lura provides handler implementation for two helper endpoints, namely "/__echo" and "/__debug".

Add caddyfile directives for enabling and customizing these endpoints.